### PR TITLE
Rename vmware-tanzu --> projectcontour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/vmware-tanzu/gimbal
+go_import_path: github.com/projectcontour/gimbal
 go:
   - 1.13.x
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN go mod download
 COPY cmd cmd
 COPY pkg pkg
 
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/kubernetes-discoverer -ldflags=-s -v github.com/vmware-tanzu/gimbal/cmd/kubernetes-discoverer
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/openstack-discoverer -ldflags=-s -v github.com/vmware-tanzu/gimbal/cmd/openstack-discoverer
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/kubernetes-discoverer -ldflags=-s -v github.com/projectcontour/gimbal/cmd/kubernetes-discoverer
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-ldflags=-w go build -o /go/bin/openstack-discoverer -ldflags=-s -v github.com/projectcontour/gimbal/cmd/openstack-discoverer
 
 FROM scratch AS final
 COPY --from=build /go/bin/kubernetes-discoverer /go/bin/kubernetes-discoverer

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/images/gimbal-logo.png" width="400px" > [![Build Status](https://travis-ci.org/vmware-tanzu/gimbal.svg?branch=master)](https://travis-ci.org/vmware-tanzu/gimbal)
+# <img src="docs/images/gimbal-logo.png" width="400px" > [![Build Status](https://travis-ci.org/projectcontour/gimbal.svg?branch=master)](https://travis-ci.org/projectcontour/gimbal)
 
 ## Overview
 
@@ -34,11 +34,11 @@ Documentation for all the Gimbal components can be found in the [docs directory]
 
 * Upstream Kubernetes Pods and OpenStack VMs must be routable from the Gimbal load balancing cluster.
   * Support is not available for Kubernetes clusters with overlay networks.
-  * We are looking for community feedback on design requirements for a solution. A possible option is one GRE tunnel per upstream cluster. [Feedback welcome here](https://github.com/vmware-tanzu/gimbal/issues/39)!
+  * We are looking for community feedback on design requirements for a solution. A possible option is one GRE tunnel per upstream cluster. [Feedback welcome here](https://github.com/projectcontour/gimbal/issues/39)!
 
 ## Troubleshooting
 
-If you encounter any problems that the documentation does not address, please [file an issue](https://github.com/vmware-tanzu/gimbal/issues) or talk to us on the Kubernetes Slack team channel [#gimbal](https://kubernetes.slack.com/messages/gimbal).
+If you encounter any problems that the documentation does not address, please [file an issue](https://github.com/projectcontour/gimbal/issues) or talk to us on the Kubernetes Slack team channel [#gimbal](https://kubernetes.slack.com/messages/gimbal).
 
 ## Contributing
 
@@ -51,4 +51,4 @@ Thanks for taking the time to join our community and start contributing!
 
 ### Pull Requests
 
-- We welcome pull requests. Fee free to dig through the [issues](https://github.com/vmware-tanzu/gimbal/issues) and jump in.
+- We welcome pull requests. Fee free to dig through the [issues](https://github.com/projectcontour/gimbal/issues) and jump in.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,4 +2,4 @@
 
 Thanks for trying out Gimbal! We welcome all feedback, please consider opening an issue:
 
-- [Issues](https://github.com/vmware-tanzu/gimbal/issues)
+- [Issues](https://github.com/projectcontour/gimbal/issues)

--- a/cmd/kubernetes-discoverer/main.go
+++ b/cmd/kubernetes-discoverer/main.go
@@ -21,14 +21,14 @@ import (
 	"os"
 	"time"
 
-	"github.com/vmware-tanzu/gimbal/pkg/buildinfo"
+	"github.com/projectcontour/gimbal/pkg/buildinfo"
 
+	"github.com/projectcontour/gimbal/pkg/k8s"
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
+	"github.com/projectcontour/gimbal/pkg/signals"
+	"github.com/projectcontour/gimbal/pkg/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
-	"github.com/vmware-tanzu/gimbal/pkg/k8s"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
-	"github.com/vmware-tanzu/gimbal/pkg/signals"
-	"github.com/vmware-tanzu/gimbal/pkg/util"
 	_ "k8s.io/api/core/v1"
 	kubeinformers "k8s.io/client-go/informers"
 )

--- a/cmd/openstack-discoverer/main.go
+++ b/cmd/openstack-discoverer/main.go
@@ -25,17 +25,17 @@ import (
 	"os"
 	"time"
 
-	"github.com/vmware-tanzu/gimbal/pkg/buildinfo"
-	"github.com/vmware-tanzu/gimbal/pkg/openstack"
+	"github.com/projectcontour/gimbal/pkg/buildinfo"
+	"github.com/projectcontour/gimbal/pkg/openstack"
 
 	"github.com/gophercloud/gophercloud"
 	gopheropenstack "github.com/gophercloud/gophercloud/openstack"
+	"github.com/projectcontour/gimbal/pkg/k8s"
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
+	"github.com/projectcontour/gimbal/pkg/signals"
+	"github.com/projectcontour/gimbal/pkg/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
-	"github.com/vmware-tanzu/gimbal/pkg/k8s"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
-	"github.com/vmware-tanzu/gimbal/pkg/signals"
-	"github.com/vmware-tanzu/gimbal/pkg/util"
 )
 
 var (

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -26,7 +26,7 @@
 - A copy of this repository. Download, or clone: 
 
   ```sh
-  $ git clone git@github.com:vmware-tanzu/gimbal.git
+  $ git clone git@github.com:projectcontour/gimbal.git
   ```
 
 - A single Kubernetes cluster to deploy Gimbal

--- a/docs/route.md
+++ b/docs/route.md
@@ -1,6 +1,6 @@
 # Route Specification
 
-The core of Gimbal is IngressRoutes, which allow traffic to be routed into one or more applications. This section will discuss how to utilize [Contour IngressRoute](https://github.com/vmware-tanzu/contour/blob/master/docs/ingressroute.md) objects to create these definitions.
+The core of Gimbal is IngressRoutes, which allow traffic to be routed into one or more applications. This section will discuss how to utilize [Contour IngressRoute](https://github.com/projectcontour/contour/blob/master/docs/ingressroute.md) objects to create these definitions.
 
 Before beginning it is important to understand how service discovery functions within Gimbal. The Discoverer components should be deployed per upstream cluster. Once synchronized, services will show up in your team namespace with the cluster name appended.
 
@@ -27,7 +27,7 @@ spec:
 
 ## IngressRoute Features
 
-The IngressRoute API provides a number of [enhancements](https://github.com/vmware-tanzu/contour/blob/master/docs/ingressroute.md#key-ingressroute-benefits) over Kubernetes Ingress:
+The IngressRoute API provides a number of [enhancements](https://github.com/projectcontour/contour/blob/master/docs/ingressroute.md#key-ingressroute-benefits) over Kubernetes Ingress:
 
 * Weight shifting
 * Multiple services per route
@@ -36,15 +36,15 @@ The IngressRoute API provides a number of [enhancements](https://github.com/vmwa
 
 ## IngressRoute Delegation
 
-Gimbal's multi-team support is enabled through Contour's [IngressRoute Delegation](https://github.com/vmware-tanzu/contour/blob/master/docs/ingressroute.md#ingressroute-delegation).
+Gimbal's multi-team support is enabled through Contour's [IngressRoute Delegation](https://github.com/projectcontour/contour/blob/master/docs/ingressroute.md#ingressroute-delegation).
 
 ### Restricted root namespaces
 
-Contour has an [enforcing mode](https://github.com/vmware-tanzu/contour/blob/master/docs/ingressroute.md#restricted-root-namespaces) which accepts a list of namespaces where root IngressRoutes are valid.
+Contour has an [enforcing mode](https://github.com/projectcontour/contour/blob/master/docs/ingressroute.md#restricted-root-namespaces) which accepts a list of namespaces where root IngressRoutes are valid.
 Only users permitted to operate in those namespaces can therefore create IngressRoutes with the `virtualhost` field.
 
 This restricted mode is enabled in Contour by specifying a command line flag, `--ingressroute-root-namespaces`, which will restrict Contour to only searching the defined namespaces for root IngressRoutes.
 
 ## Additional Information
 
-More information regarding IngressRoutes can be found in the [Contour Documentation](https://github.com/vmware-tanzu/contour/blob/master/docs/ingressroute.md)
+More information regarding IngressRoutes can be found in the [Contour Documentation](https://github.com/projectcontour/contour/blob/master/docs/ingressroute.md)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmware-tanzu/gimbal
+module github.com/projectcontour/gimbal
 
 go 1.13
 

--- a/pkg/k8s/controller.go
+++ b/pkg/k8s/controller.go
@@ -16,12 +16,12 @@ package k8s
 import (
 	"fmt"
 
-	"github.com/vmware-tanzu/gimbal/pkg/translator"
+	"github.com/projectcontour/gimbal/pkg/translator"
 
 	"github.com/sirupsen/logrus"
 
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
-	"github.com/vmware-tanzu/gimbal/pkg/sync"
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
+	"github.com/projectcontour/gimbal/pkg/sync"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
+	"github.com/projectcontour/gimbal/pkg/sync"
 	"github.com/prometheus/client_golang/prometheus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
-	"github.com/vmware-tanzu/gimbal/pkg/sync"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"

--- a/pkg/k8s/translate.go
+++ b/pkg/k8s/translate.go
@@ -14,7 +14,7 @@
 package k8s
 
 import (
-	"github.com/vmware-tanzu/gimbal/pkg/translator"
+	"github.com/projectcontour/gimbal/pkg/translator"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/openstack/httplogger.go
+++ b/pkg/openstack/httplogger.go
@@ -20,8 +20,8 @@ import (
 	"net/http/httptrace"
 	"time"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 )
 
 // LogRoundTripper satisfies the http.RoundTripper interface and is used to

--- a/pkg/openstack/reconciler.go
+++ b/pkg/openstack/reconciler.go
@@ -18,14 +18,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vmware-tanzu/gimbal/pkg/translator"
+	"github.com/projectcontour/gimbal/pkg/translator"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools"
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
+	"github.com/projectcontour/gimbal/pkg/sync"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
-	"github.com/vmware-tanzu/gimbal/pkg/sync"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/openstack/translate.go
+++ b/pkg/openstack/translate.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vmware-tanzu/gimbal/pkg/translator"
+	"github.com/projectcontour/gimbal/pkg/translator"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"

--- a/pkg/sync/endpoints.go
+++ b/pkg/sync/endpoints.go
@@ -17,8 +17,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/sync/endpoints_test.go
+++ b/pkg/sync/endpoints_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 	"time"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/sync/queue.go
+++ b/pkg/sync/queue.go
@@ -16,8 +16,8 @@ package sync
 import (
 	"time"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/sync/queue_test.go
+++ b/pkg/sync/queue_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/vmware-tanzu/gimbal/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/sync/service.go
+++ b/pkg/sync/service.go
@@ -17,8 +17,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/sync/service_test.go
+++ b/pkg/sync/service_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	localmetrics "github.com/projectcontour/gimbal/pkg/metrics"
 	"github.com/sirupsen/logrus"
-	localmetrics "github.com/vmware-tanzu/gimbal/pkg/metrics"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
This updates the code base from the Github org move from `vmware-tanzu` --> `projectcontour`. 

Signed-off-by: Steve Sloka <slokas@vmware.com>