### PR TITLE
Rename gimbal labels to 'gimbal.projectcontour.io'

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -179,7 +179,7 @@ NAME            READY     STATUS    RESTARTS   AGE
 contour-lq6mm   2/2       Running   0          5h
 
 # Verify discovered services
-$ kubectl get svc -l gimbal.heptio.com/backend
+$ kubectl get svc -l gimbal.projectcontour.io/backend
 NAME                TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 nginx-node02        ClusterIP   None         <none>        80/TCP    17m
 kuard-node02        ClusterIP   None         <none>        80/TCP    17m

--- a/design/kubernetes.md
+++ b/design/kubernetes.md
@@ -22,8 +22,8 @@ In order for an Ingress controller to route traffic to endpoints off-cluster, we
 ```
 Name:              nginx-node02
 Namespace:         team1
-Labels:            gimbal.heptio.com/service=nginx
-                   gimbal.heptio.com/backend=node02
+Labels:            gimbal.projectcontour.io/service=nginx
+                   gimbal.projectcontour.io/backend=node02
                    run=nginx
 Annotations:       <none>
 Selector:          <none>
@@ -41,8 +41,8 @@ Events:            <none>
 ```
 Name:         nginx-node02
 Namespace:    team1
-Labels:       gimbal.heptio.com/service=nginx
-              gimbal.heptio.com/backend=node02
+Labels:       gimbal.projectcontour.io/service=nginx
+              gimbal.projectcontour.io/backend=node02
               run=nginx
 Annotations:  <none>
 Subsets:
@@ -76,8 +76,8 @@ If additional processing is required, then an argument can be changed to increas
 
 Those labels are defined as:
 
-- gimbal.heptio.com/backend: BackendName (Defined via argument)
-- gimbal.heptio.com/service: [ServiceName]
+- gimbal.projectcontour.io/backend: BackendName (Defined via argument)
+- gimbal.projectcontour.io/service: [ServiceName]
 
 The name of the synchronized object will be a hash of the `BackendName-ServiceName`. The name is hashed because of length restrictions when creating a service object.
 

--- a/docs/discovery-naming-conventions.md
+++ b/docs/discovery-naming-conventions.md
@@ -105,4 +105,4 @@ OpenStack can be renamed. This prevents users from unintentionally renaming
 discovered services in Kubernetes and breaking IngressRoute rules.
 
 Instead, the load balancer's name is available as a label
-(`gimbal.heptio.com/load-balancer-name`) on the service.
+(`gimbal.projectcontour.io/load-balancer-name`) on the service.

--- a/docs/kubernetes-discoverer.md
+++ b/docs/kubernetes-discoverer.md
@@ -107,6 +107,6 @@ All synchronized services & endpoints will contain the same properties as the so
 
 Labels added to service and endpoints:
 ```
-gimbal.heptio.com/service=<serviceName>
-gimbal.heptio.com/backend=<nodeName>
+gimbal.projectcontour.io/service=<serviceName>
+gimbal.projectcontour.io/backend=<nodeName>
 ```

--- a/docs/list-discovered-services.md
+++ b/docs/list-discovered-services.md
@@ -5,7 +5,7 @@ The Gimbal Discoverers add labels to the discovered services and endpoints befor
 ## List all discovered services and endpoints
 
 ```sh
-kubectl get svc,endpoints -l gimbal.heptio.com/backend
+kubectl get svc,endpoints -l gimbal.projectcontour.io/backend
 ```
 
 You can add `--all-namespaces` to list across all namespaces in the Gimbal cluster.
@@ -13,14 +13,14 @@ You can add `--all-namespaces` to list across all namespaces in the Gimbal clust
 ## List services and endpoints that were discovered from a specific cluster
 
 ```sh
-kubectl get svc,endpoints -l gimbal.heptio.com/backend=${CLUSTER_NAME}
+kubectl get svc,endpoints -l gimbal.projectcontour.io/backend=${CLUSTER_NAME}
 ```
 
 ## List services that belong to the same logical service
 
-If you have instances of a service spread across clusters, you can use the `gimbal.heptio.com/service` label to list
+If you have instances of a service spread across clusters, you can use the `gimbal.projectcontour.io/service` label to list
 them:
 
 ```sh
-kubectl get svc,endpoints -l gimbal.heptio.com/service=${SERVICE_NAME}
+kubectl get svc,endpoints -l gimbal.projectcontour.io/service=${SERVICE_NAME}
 ```

--- a/docs/manage-backends.md
+++ b/docs/manage-backends.md
@@ -83,20 +83,20 @@ To remove a backend from the Gimbal cluster, the Discoverer and the discovered s
 1. List the Services that belong to the cluster, and verify the list:
 
     ```sh
-    kubectl --all-namespaces get svc -l gimbal.heptio.com/backend=${CLUSTER_NAME}
+    kubectl --all-namespaces get svc -l gimbal.projectcontour.io/backend=${CLUSTER_NAME}
     ```
 
 1. List the namespaces with Services that were discovered:
 
     ```sh
-    kubectl get svc --all-namespaces  -l gimbal.heptio.com/backend=${CLUSTER_NAME} -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq
+    kubectl get svc --all-namespaces  -l gimbal.projectcontour.io/backend=${CLUSTER_NAME} -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq
     ```
 
 1. Iterate over the namespaces and delete all Services and Endpoints:
 
     ```sh
-    NAMESPACES=$(kubectl get svc --all-namespaces  -l gimbal.heptio.com/backend=${CLUSTER_NAME} -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq)
+    NAMESPACES=$(kubectl get svc --all-namespaces  -l gimbal.projectcontour.io/backend=${CLUSTER_NAME} -o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | uniq)
     for ns in $NAMESPACES
     do
-        kubectl -n $ns delete svc,endpoints -l gimbal.heptio.com/backend=${CLUSTER_NAME}
+        kubectl -n $ns delete svc,endpoints -l gimbal.projectcontour.io/backend=${CLUSTER_NAME}
     done

--- a/docs/openstack-discoverer.md
+++ b/docs/openstack-discoverer.md
@@ -123,8 +123,8 @@ All synchronized services & endpoints will have additional labels added to assis
 
 Labels added to service and endpoints:
 ```
-gimbal.heptio.com/service=<serviceName>
-gimbal.heptio.com/backend=<nodeName>
-gimbal.heptio.com/load-balancer-id=<LoadBalancer.ID>
-gimbal.heptio.com/load-balancer-name=<LoadBalancer..Name>
+gimbal.projectcontour.io/service=<serviceName>
+gimbal.projectcontour.io/backend=<nodeName>
+gimbal.projectcontour.io/load-balancer-id=<LoadBalancer.ID>
+gimbal.projectcontour.io/load-balancer-name=<LoadBalancer..Name>
 ```

--- a/pkg/k8s/controller_test.go
+++ b/pkg/k8s/controller_test.go
@@ -94,7 +94,7 @@ var serviceTests = []struct {
 				Name:      "kubernetes",
 				Namespace: "default",
 				Labels: map[string]string{
-					"gimbal.heptio.com/backend": "zzzzz",
+					"gimbal.projectcontour.io/backend": "zzzzz",
 				},
 			},
 			Spec: v1.ServiceSpec{

--- a/pkg/k8s/translate_test.go
+++ b/pkg/k8s/translate_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -51,7 +51,7 @@ func TestTranslateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "default",
 					Name:        "cluster1-kuard",
-					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Labels:      map[string]string{"app": "kuard", "gimbal.projectcontour.io/backend": "cluster1", "gimbal.projectcontour.io/service": "kuard"},
 					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
@@ -85,7 +85,7 @@ func TestTranslateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "default",
 					Name:        "cluster1-kuard",
-					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Labels:      map[string]string{"app": "kuard", "gimbal.projectcontour.io/backend": "cluster1", "gimbal.projectcontour.io/service": "kuard"},
 					Annotations: map[string]string{"foo": "bar"},
 				},
 				Spec: v1.ServiceSpec{
@@ -136,7 +136,7 @@ func TestTranslateEndpoints(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "default",
 					Name:        "cluster1-kuard",
-					Labels:      map[string]string{"app": "kuard", "gimbal.heptio.com/backend": "cluster1", "gimbal.heptio.com/service": "kuard"},
+					Labels:      map[string]string{"app": "kuard", "gimbal.projectcontour.io/backend": "cluster1", "gimbal.projectcontour.io/service": "kuard"},
 					Annotations: map[string]string{"foo": "bar"},
 				},
 				Subsets: []v1.EndpointSubset{

--- a/pkg/openstack/translate.go
+++ b/pkg/openstack/translate.go
@@ -120,8 +120,8 @@ func loadbalancerLabels(lb loadbalancers.LoadBalancer) map[string]string {
 		name = translator.ShortenKubernetesLabelValue(name)
 	}
 	return map[string]string{
-		"gimbal.heptio.com/load-balancer-id":   lb.ID,
-		"gimbal.heptio.com/load-balancer-name": name,
+		"gimbal.projectcontour.io/load-balancer-id":   lb.ID,
+		"gimbal.projectcontour.io/load-balancer-name": name,
 	}
 }
 

--- a/pkg/openstack/translate_test.go
+++ b/pkg/openstack/translate_test.go
@@ -44,10 +44,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": ""},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": ""},
 					nil),
 			},
 		},
@@ -61,10 +61,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					nil),
 			},
 		},
@@ -78,10 +78,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
 					nil),
 			},
 		},
@@ -95,10 +95,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "1234-stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "1234-stocks"},
 					nil),
 			},
 		},
@@ -112,10 +112,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "1234-STOCKS"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "1234-STOCKS"},
 					nil),
 			},
 		},
@@ -129,10 +129,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo----------_-bar"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo----------_-bar"},
 					nil),
 			},
 		},
@@ -146,10 +146,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "bar-8080"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "bar-8080"},
 					nil),
 			},
 		},
@@ -163,10 +163,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo-bar_BAZ.123"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo-bar_BAZ.123"},
 					nil),
 			},
 		},
@@ -180,10 +180,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "lb-foo"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "lb-foo"},
 					nil),
 			},
 		},
@@ -197,10 +197,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo-lb"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo-lb"},
 					nil),
 			},
 		},
@@ -214,10 +214,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo-lb"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo-lb"},
 					nil),
 			},
 		},
@@ -231,10 +231,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo_lb"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo_lb"},
 					nil),
 			},
 		},
@@ -248,10 +248,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "foo.lb"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "foo.lb"},
 					nil),
 			},
 		},
@@ -265,10 +265,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "lb-foo-lb"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "lb-foo-lb"},
 					nil),
 			},
 		},
@@ -282,10 +282,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "cluster-name-that-is-defib224b3-5a5c3d9e-e679-43ec-b9fc-9f5b1ae",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "nginx"},
+						"gimbal.projectcontour.io/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "nginx"},
 					nil),
 			},
 		},
@@ -299,10 +299,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "cluster-name-that-is-defib224b3-5a5c3d9e-e679-43ec-b9fc-9f5b1ae",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
+						"gimbal.projectcontour.io/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
 					nil),
 			},
 		},
@@ -316,10 +316,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
 							Name:       "port-80",
@@ -340,10 +340,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
 							Name:       "port-80",
@@ -364,10 +364,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.ServicePort{
 						{
 							Name:       "port-80",
@@ -394,10 +394,10 @@ func TestKubeServices(t *testing.T) {
 			expected: []v1.Service{
 				service("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": ""},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": ""},
 					[]v1.ServicePort{
 						{
 							Name:       "port-80",
@@ -447,10 +447,10 @@ func TestKubeEndpoints(t *testing.T) {
 			expected: []v1.Endpoints{
 				endpoints("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.EndpointSubset{
 						{
 							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
@@ -472,10 +472,10 @@ func TestKubeEndpoints(t *testing.T) {
 			expected: []v1.Endpoints{
 				endpoints("finance", "cluster-name-that-is-defi7afb09-5a5c3d9e-e679-43ec-b9fc-9f5b1ae",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful-in-7afb09",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "cluster-name-that-is-definitely-too-long-to-be-useful-in-7afb09",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.EndpointSubset{
 						{
 							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
@@ -497,10 +497,10 @@ func TestKubeEndpoints(t *testing.T) {
 			expected: []v1.Endpoints{
 				endpoints("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "very-long-openstack-load-balancer-name-that-is-longer-tha80b28c"},
 					[]v1.EndpointSubset{
 						{
 							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}},
@@ -523,10 +523,10 @@ func TestKubeEndpoints(t *testing.T) {
 			expected: []v1.Endpoints{
 				endpoints("finance", "us-east-5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
 					map[string]string{
-						"gimbal.heptio.com/backend":            "us-east",
-						"gimbal.heptio.com/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
-						"gimbal.heptio.com/load-balancer-name": "stocks"},
+						"gimbal.projectcontour.io/backend":            "us-east",
+						"gimbal.projectcontour.io/service":            "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-id":   "5a5c3d9e-e679-43ec-b9fc-9bc51132541e",
+						"gimbal.projectcontour.io/load-balancer-name": "stocks"},
 					[]v1.EndpointSubset{
 						{
 							Addresses: []v1.EndpointAddress{{IP: "10.0.0.1"}, {IP: "10.0.0.4"}},

--- a/pkg/sync/endpoints_test.go
+++ b/pkg/sync/endpoints_test.go
@@ -166,7 +166,7 @@ func TestDiscovererEndpointsMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 				Subsets: []v1.EndpointSubset{
@@ -188,7 +188,7 @@ func TestDiscovererEndpointsMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 				Subsets: []v1.EndpointSubset{
@@ -214,7 +214,7 @@ func TestDiscovererEndpointsMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 				Subsets: []v1.EndpointSubset{

--- a/pkg/sync/service.go
+++ b/pkg/sync/service.go
@@ -144,7 +144,7 @@ func (action serviceAction) SetMetricError(metrics localmetrics.DiscovererMetric
 
 // GetTotalServicesCount returns the number of services in a namespace for the particular backend
 func getTotalServicesCount(gimbalKubeClient kubernetes.Interface, namespace string, metrics localmetrics.DiscovererMetrics) (int, error) {
-	svcs, err := gimbalKubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("gimbal.heptio.com/backend=%s", metrics.BackendName)})
+	svcs, err := gimbalKubeClient.CoreV1().Services(namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("gimbal.projectcontour.io/backend=%s", metrics.BackendName)})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sync/service_test.go
+++ b/pkg/sync/service_test.go
@@ -165,7 +165,7 @@ func TestDiscovererServiceMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 			},
@@ -186,7 +186,7 @@ func TestDiscovererServiceMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 			},
@@ -195,7 +195,7 @@ func TestDiscovererServiceMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "existing",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 			},
@@ -215,7 +215,7 @@ func TestDiscovererServiceMetrics(t *testing.T) {
 					Namespace: "foo",
 					Name:      "bar",
 					Labels: map[string]string{
-						"gimbal.heptio.com/backend": backendName,
+						"gimbal.projectcontour.io/backend": backendName,
 					},
 				},
 			},

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	// GimbalLabelBackend is the key of the label that contains the cluster name
-	GimbalLabelBackend          = "gimbal.heptio.com/backend"
-	gimbalLabelService          = "gimbal.heptio.com/service"
+	GimbalLabelBackend          = "gimbal.projectcontour.io/backend"
+	gimbalLabelService          = "gimbal.projectcontour.io/service"
 	maxKubernetesDNSLabelLength = 63
 )
 

--- a/pkg/translator/translator_test.go
+++ b/pkg/translator/translator_test.go
@@ -123,8 +123,8 @@ func TestAddLabels(t *testing.T) {
 			serviceName: "service01",
 			podLabels:   nil,
 			expected: map[string]string{
-				"gimbal.heptio.com/backend": "test01",
-				"gimbal.heptio.com/service": "service01",
+				"gimbal.projectcontour.io/backend": "test01",
+				"gimbal.projectcontour.io/service": "service01",
 			},
 		},
 		{
@@ -135,9 +135,9 @@ func TestAddLabels(t *testing.T) {
 				"key1": "value1",
 			},
 			expected: map[string]string{
-				"gimbal.heptio.com/backend": "test01",
-				"gimbal.heptio.com/service": "service01",
-				"key1":                      "value1",
+				"gimbal.projectcontour.io/backend": "test01",
+				"gimbal.projectcontour.io/service": "service01",
+				"key1":                             "value1",
 			},
 		},
 		{
@@ -145,14 +145,14 @@ func TestAddLabels(t *testing.T) {
 			backendName: "test01",
 			serviceName: "service01",
 			podLabels: map[string]string{
-				"gimbal.heptio.com/backend": "badBackendName",
-				"gimbal.heptio.com/service": "badService",
-				"key1":                      "value1",
+				"gimbal.projectcontour.io/backend": "badBackendName",
+				"gimbal.projectcontour.io/service": "badService",
+				"key1":                             "value1",
 			},
 			expected: map[string]string{
-				"gimbal.heptio.com/backend": "test01",
-				"gimbal.heptio.com/service": "service01",
-				"key1":                      "value1",
+				"gimbal.projectcontour.io/backend": "test01",
+				"gimbal.projectcontour.io/service": "service01",
+				"key1":                             "value1",
 			},
 		},
 		{
@@ -161,8 +161,8 @@ func TestAddLabels(t *testing.T) {
 			serviceName: "service01",
 			podLabels:   nil,
 			expected: map[string]string{
-				"gimbal.heptio.com/backend": "a-really-long-cluster-name-that-does-not-really-make-sensfb8867",
-				"gimbal.heptio.com/service": "service01",
+				"gimbal.projectcontour.io/backend": "a-really-long-cluster-name-that-does-not-really-make-sensfb8867",
+				"gimbal.projectcontour.io/service": "service01",
 			},
 		},
 		{
@@ -171,8 +171,8 @@ func TestAddLabels(t *testing.T) {
 			serviceName: "a-really-long-service-name-that-does-not-really-make-sense-and-is-not-useful-at-all",
 			podLabels:   nil,
 			expected: map[string]string{
-				"gimbal.heptio.com/backend": "cluster01",
-				"gimbal.heptio.com/service": "a-really-long-service-name-that-does-not-really-make-sens1c0b9b",
+				"gimbal.projectcontour.io/backend": "cluster01",
+				"gimbal.projectcontour.io/service": "a-really-long-service-name-that-does-not-really-make-sens1c0b9b",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #280 by renaming the `gimbal.heptio.com` labels to `gimbal.projectcontour.io`. 

Signed-off-by: Steve Sloka <slokas@vmware.com>