### PR TITLE
update prometheus metric labels for envoy dashboard

### DIFF
--- a/deployment/grafana/02-grafana-configmap.yaml
+++ b/deployment/grafana/02-grafana-configmap.yaml
@@ -2930,10 +2930,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_rq_total{namespace=~\"$Namespace\",service=~\"$Service\"}[1m])) by (service,namespace)",
+              "expr": "sum(rate(envoy_cluster_upstream_rq_total{envoy_cluster_name=~\"${Namespace}_.*\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3014,10 +3014,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_cx_total{namespace=~\"$Namespace\",service=~\"$Service\"}[1m])) by (namespace, service)",
+              "expr": "sum(rate(envoy_cluster_upstream_cx_total{envoy_cluster_name=~\"${Namespace}_.*\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3098,26 +3098,26 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{service=~\"$Service\",namespace=~\"$Namespace\"}[1m])) by (le, service, namespace))",
+              "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{envoy_cluster_name=~\"${Namespace}_.*\"}[1m])) by (le, envoy_cluster_name))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{namespace}}/{{service}} 99%",
+              "legendFormat": "{{envoy_cluster_name}} 99%",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.9, sum(rate(envoy_cluster_upstream_rq_time_bucket{service=~\"$Service\",namespace=~\"$Namespace\"}[1m])) by (le, service, namespace))",
+              "expr": "histogram_quantile(0.9, sum(rate(envoy_cluster_upstream_rq_time_bucket{envoy_cluster_name=~\"${Namespace}_.*\"}[1m])) by (le, envoy_cluster_name))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{namespace}}/{{service}} 90%",
-              "refId": "C"
+              "legendFormat": "{{envoy_cluster_name}} 90%",
+              "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.5, sum(rate(envoy_cluster_upstream_rq_time_bucket{service=~\"$Service\",namespace=~\"$Namespace\"}[1m])) by (le, service, namespace))",
+              "expr": "histogram_quantile(0.5, sum(rate(envoy_cluster_upstream_rq_time_bucket{envoy_cluster_name=~\"${Namespace}_.*\"}[1m])) by (le, envoy_cluster_name))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "{{namespace}}/{{service}} 50% ",
-              "refId": "B"
+              "legendFormat": "{{envoy_cluster_name}} 50% ",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -3197,10 +3197,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(envoy_cluster_upstream_cx_active{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service)",
+              "expr": "sum(envoy_cluster_upstream_cx_active{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3283,10 +3283,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{namespace=~\"$Namespace\",service=~\"$Service\",envoy_response_code_class=~\"2\"}[1m])) by (namespace,service)",
+              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_cluster_name=~\"${Namespace}_.*\", envoy_response_code_class=~\"2\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3368,10 +3368,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{namespace=~\"$Namespace\",service=~\"$Service\",envoy_response_code_class=\"3\"}[1m])) by (namespace,service)",
+              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_cluster_name=~\"${Namespace}_.*\", envoy_response_code_class=~\"3\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3453,10 +3453,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{namespace=~\"$Namespace\",service=~\"$Service\",envoy_response_code_class=\"4\"}[1m])) by (namespace,service)",
+              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_cluster_name=~\"${Namespace}_.*\", envoy_response_code_class=~\"4\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3538,10 +3538,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{namespace=~\"$Namespace\",service=~\"$Service\",envoy_response_code_class=\"5\"}[1m])) by (namespace,service)",
+              "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_cluster_name=~\"${Namespace}_.*\", envoy_response_code_class=~\"5\"}[1m])) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3624,10 +3624,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(envoy_cluster_membership_healthy{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service) / avg(envoy_cluster_membership_total{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service)",
+              "expr": "avg(envoy_cluster_membership_healthy{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name) / avg(envoy_cluster_membership_total{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3710,10 +3710,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(envoy_cluster_membership_total{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service)",
+              "expr": "avg(envoy_cluster_membership_total{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3796,10 +3796,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(envoy_cluster_membership_healthy{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service)",
+              "expr": "avg(envoy_cluster_membership_healthy{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3882,10 +3882,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(envoy_cluster_membership_total{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service) - avg(envoy_cluster_membership_healthy{namespace=~\"$Namespace\",service=~\"$Service\"}) by (namespace, service)",
+              "expr": "avg(envoy_cluster_membership_total{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name) - avg(envoy_cluster_membership_healthy{envoy_cluster_name=~\"${Namespace}_.*\"}) by (envoy_cluster_name)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{namespace}}/{{service}}",
+              "legendFormat": "{{envoy_cluster_name}}",
               "refId": "A"
             }
           ],
@@ -3942,27 +3942,7 @@ data:
             "multi": true,
             "name": "Namespace",
             "options": [],
-            "query": "label_values(envoy_cluster_upstream_rq_time_bucket,namespace)",
-            "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
-          {
-            "allValue": ".*",
-            "current": {},
-            "datasource": "prometheus",
-            "hide": 0,
-            "includeAll": true,
-            "label": null,
-            "multi": true,
-            "name": "Service",
-            "options": [],
-            "query": "label_values(envoy_cluster_upstream_rq_time_bucket,service)",
+            "query": "label_values(namespace)",
             "refresh": 2,
             "regex": "",
             "sort": 0,


### PR DESCRIPTION
Fix for #267 

Envoy metric labels seem to be changed to use `envoy_cluster_name`.
This PR follows the change for Envoy Metrics dashboard on grafana.

Signed-off-by: Hirotaka Ichikawa <hichtakk@gmail.com>